### PR TITLE
fix: align appVersion with chart version (both 1.1.4)

### DIFF
--- a/.github/workflows/update_semantic_version-dynamic.yml
+++ b/.github/workflows/update_semantic_version-dynamic.yml
@@ -81,5 +81,6 @@ jobs:
         message: 'Update Helm Chart version to ${{ steps.tag_version.outputs.new_tag }}'
         changes: |
           {
-            "version": "${{ steps.tag_version.outputs.new_tag }}"
+            "version": "${{ steps.tag_version.outputs.new_tag }}",
+            "appVersion": "${{ steps.tag_version.outputs.new_tag }}"
           }

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
     name: Marcus Aleksandravicius
 name: secrets-injector
 version: 1.1.4
-appVersion: 1.1.3
+appVersion: 1.1.4


### PR DESCRIPTION
## Summary

The Release Version workflow was only updating the chart `version` field but not `appVersion`, causing a mismatch after the 1.1.4 release (version=1.1.4, appVersion=1.1.3).

## Fix

1. **Immediate fix**: Set `appVersion: 1.1.4` in chart/Chart.yaml to match `version: 1.1.4`
2. **Preventive fix**: Updated the `yaml-update` action in `update_semantic_version-dynamic.yml` to atomically set both `version` and `appVersion` to the new tag, preventing this drift from happening again.

## Testing

- `helm lint chart/` → 1 chart linted, 0 failed