### PR TITLE
fix: chart appVersion sync + deprecated release actions

### DIFF
--- a/.github/workflows/update_semantic_version-dynamic.yml
+++ b/.github/workflows/update_semantic_version-dynamic.yml
@@ -48,7 +48,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create Production Release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@v2
       id: release
       with:
         tag: ${{ steps.tag_version.outputs.new_tag }}
@@ -69,7 +69,7 @@ jobs:
         helm push *.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts
 
     - name: Update Base Chart version
-      uses: fjogeleit/yaml-update-action@main
+      uses: fjogeleit/yaml-update-action@v0.18.0
       with:
         valueFile: 'chart/Chart.yaml'
         repository: 'marcus1aleksand/secrets-injector'

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
     name: Marcus Aleksandravicius
 name: secrets-injector
 version: 1.1.4
-appVersion: 1.1.3
+appVersion: 1.1.4


### PR DESCRIPTION
## Summary

### Bug Fix
**Chart appVersion out of sync with release tag** (`chart/Chart.yaml`)
- `appVersion: 1.1.3` but the latest release tag is `1.1.4`.
- Updated `appVersion` to `1.1.4` to match the release.

### Pipeline Fixes
**Deprecated actions in release workflow** (`.github/workflows/update_semantic_version-dynamic.yml`)
- `ncipollo/release-action@v1` → `v2` (v1 is years old and unmaintained)
- `fjogeleit/yaml-update-action@main` → `@v0.18.0` (pin to a release tag for stability)

---
*Review by Mark (dev_agent) — 2026-04-17*
